### PR TITLE
Allow multiple identifiers in OvProductType and OvagentType and allow multiple TEL values in OvcontactType

### DIFF
--- a/OSLO-CommonBasicComponents-1.0.xsd
+++ b/OSLO-CommonBasicComponents-1.0.xsd
@@ -83,7 +83,7 @@
           <xsd:element name="productType" type="OvcodeType" minOccurs="1" maxOccurs="1" />
           <xsd:element name="coverage" type="locn:CvlocationType"  maxOccurs="1" />
           <xsd:element ref="validityPeriod" />
-          <xsd:element ref="identifier" minOccurs="1" />
+          <xsd:element ref="identifier" minOccurs="1" maxOccurs="unbounded" />
         </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>
@@ -161,7 +161,7 @@
       <xsd:element ref="cbc:UBLVersionID" minOccurs="0"/>
       <xsd:element ref="cbc:CustomizationID" minOccurs="0"/>
       <xsd:element ref="cbc:ProfileID" minOccurs="0"/>
-      <xsd:element ref="ovc:identifier" minOccurs="1" />
+      <xsd:element ref="ovc:identifier" minOccurs="1" maxOccurs="unbounded"/>
     </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="OsloBuildingType">

--- a/OsloContact.xsd
+++ b/OsloContact.xsd
@@ -29,7 +29,7 @@
             <xsd:element ref="cbc:ProfileID" minOccurs="0"/>
             <xsd:element ref="vcard:NICKNAME" minOccurs="0" maxOccurs="1"/>
             <xsd:element ref="vcard:EMAIL" minOccurs="0"/>
-            <xsd:element ref="vcard:TEL" minOccurs="0"/>
+            <xsd:element ref="vcard:TEL" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element ref="vcard:URL" minOccurs="0"/>
             <xsd:element ref="vcard:UID" minOccurs="0"/>
             <xsd:element ref="vcard:TITLE" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
The same element TEL is used for 'telefoon', 'fax' and 'mobiel' and multiple values of each are allowed according to the specs.

from the v1.0 specs:
"Telefoon, Mobiel en Fax zijn niet verplichte attributen die meerdere keren mogen voorkomen."
