### PR TITLE
LocatorDesignator in OsloAddressType made optional (minOccurs="0")

### DIFF
--- a/OSLO-CommonBasicComponents-1.0.xsd
+++ b/OSLO-CommonBasicComponents-1.0.xsd
@@ -126,7 +126,7 @@
     <xsd:complexContent>
       <xsd:extension base="cva:CvaddressType">
         <xsd:sequence>
-          <xsd:element ref="addr:LocatorDesignator" />
+          <xsd:element ref="addr:LocatorDesignator" minOccurs="0"/>
           <xsd:element ref="ovc:identifier"/>
         </xsd:sequence>
       </xsd:extension>


### PR DESCRIPTION
The LocatorDesignator in OsloAddressType should be optional.
This LocatorDesignator is the one from the inspire namespace. It's used for storing 'subadres'. Most addresses don't have a 'subadres'.
